### PR TITLE
PHPStan 0.12 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,11 @@
     ],
     "require": {
         "php": "~7.1",
+        "phpstan/phpstan": "^0.11",
         "phpstan/phpstan-doctrine": "~0.11.1",
         "doctrine/collections": "^1.5",
-        "otobank/doctrine-target-aware-criteria": "^0.1.0"
+        "otobank/doctrine-target-aware-criteria": "^0.1.0",
+        "nikic/php-parser": "^4.3"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.14",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "otobank/phpstan-doctrine-criteria",
-    "description": "Doctrine Criteria aextensions for PHPStan",
+    "description": "Doctrine Criteria extensions for PHPStan",
     "keywords": ["phpstan", "doctrine"],
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "require": {
         "php": "~7.1",
-        "phpstan/phpstan": "^0.11",
-        "phpstan/phpstan-doctrine": "~0.11.1",
+        "phpstan/phpstan": "~0.11.1|~0.12",
+        "phpstan/phpstan-doctrine": "~0.11.1|~0.12",
         "doctrine/collections": "^1.5",
         "otobank/doctrine-target-aware-criteria": "^0.1.0",
         "nikic/php-parser": "^4.3"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.14",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^7.5",
+        "doctrine/common": "^2.7"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "require": {
         "php": "~7.1",
-        "phpstan/phpstan": "~0.11.1|~0.12",
-        "phpstan/phpstan-doctrine": "~0.11.1|~0.12",
+        "phpstan/phpstan": "^0.12.4",
+        "phpstan/phpstan-doctrine": "^0.12.9",
         "doctrine/collections": "^1.5",
         "otobank/doctrine-target-aware-criteria": "^0.1.0",
         "nikic/php-parser": "^4.3"

--- a/src/Rules/ProhibitCollectionCallWithAssociationsRule.php
+++ b/src/Rules/ProhibitCollectionCallWithAssociationsRule.php
@@ -22,7 +22,6 @@ class ProhibitCollectionCallWithAssociationsRule implements \PHPStan\Rules\Rule
 
     /**
      * @param \PhpParser\Node\Expr\MethodCall $node
-     * @param \PHPStan\Analyser\Scope         $scope
      *
      * @return (string|\PHPStan\Rules\RuleError)[]
      */

--- a/src/Rules/ProhibitComparisonCallRule.php
+++ b/src/Rules/ProhibitComparisonCallRule.php
@@ -22,7 +22,6 @@ class ProhibitComparisonCallRule implements \PHPStan\Rules\Rule
 
     /**
      * @param \PhpParser\Node\Expr\MethodCall $node
-     * @param \PHPStan\Analyser\Scope         $scope
      *
      * @return (string|\PHPStan\Rules\RuleError)[]
      */

--- a/src/Rules/ProhibitComparisonNewRule.php
+++ b/src/Rules/ProhibitComparisonNewRule.php
@@ -21,7 +21,6 @@ class ProhibitComparisonNewRule implements \PHPStan\Rules\Rule
 
     /**
      * @param \PhpParser\Node\Expr\MethodCall $node
-     * @param \PHPStan\Analyser\Scope         $scope
      *
      * @return (string|\PHPStan\Rules\RuleError)[]
      */

--- a/src/Rules/ProhibitCriteriaCallRule.php
+++ b/src/Rules/ProhibitCriteriaCallRule.php
@@ -18,7 +18,6 @@ class ProhibitCriteriaCallRule implements \PHPStan\Rules\Rule
 
     /**
      * @param \PhpParser\Node\Expr\MethodCall $node
-     * @param \PHPStan\Analyser\Scope         $scope
      *
      * @return (string|\PHPStan\Rules\RuleError)[]
      */

--- a/src/Rules/ProhibitCriteriaNewRule.php
+++ b/src/Rules/ProhibitCriteriaNewRule.php
@@ -21,7 +21,6 @@ class ProhibitCriteriaNewRule implements \PHPStan\Rules\Rule
 
     /**
      * @param \PhpParser\Node\Expr\MethodCall $node
-     * @param \PHPStan\Analyser\Scope         $scope
      *
      * @return (string|\PHPStan\Rules\RuleError)[]
      */

--- a/src/Rules/ValidateFieldComparisonCallRule.php
+++ b/src/Rules/ValidateFieldComparisonCallRule.php
@@ -25,7 +25,6 @@ class ValidateFieldComparisonCallRule implements \PHPStan\Rules\Rule
 
     /**
      * @param \PhpParser\Node\Expr\MethodCall $node
-     * @param \PHPStan\Analyser\Scope         $scope
      *
      * @return (string|\PHPStan\Rules\RuleError)[]
      */

--- a/src/Rules/ValidateFieldCriteriaCallRule.php
+++ b/src/Rules/ValidateFieldCriteriaCallRule.php
@@ -30,7 +30,6 @@ class ValidateFieldCriteriaCallRule implements \PHPStan\Rules\Rule
 
     /**
      * @param \PhpParser\Node\Expr\MethodCall $node
-     * @param \PHPStan\Analyser\Scope         $scope
      *
      * @return (string|\PHPStan\Rules\RuleError)[]
      */

--- a/src/Rules/ValidateTrait.php
+++ b/src/Rules/ValidateTrait.php
@@ -22,9 +22,7 @@ trait ValidateTrait
         $objectManager = $this->objectMetadataResolver->getObjectManager();
 
         if ($objectManager === null) {
-            throw new \PHPStan\ShouldNotHappenException(
-                'Please provide the "objectManagerLoader" setting.'
-            );
+            throw new \PHPStan\ShouldNotHappenException('Please provide the "objectManagerLoader" setting.');
         }
 
         $this->objectManager = $objectManager;

--- a/tests/Rules/Asset/AcmeEntity.php
+++ b/tests/Rules/Asset/AcmeEntity.php
@@ -1,0 +1,16 @@
+<?php
+
+
+namespace Otobank\PHPStan\Doctrine\Rules\Asset;
+
+
+class AcmeEntity
+{
+    private $foo;
+    private $bar;
+
+    public function getFoo() : string
+    {
+        return $this->foo;
+    }
+}

--- a/tests/Rules/Asset/AcmeEntity.php
+++ b/tests/Rules/Asset/AcmeEntity.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Otobank\PHPStan\Doctrine\Rules\Asset;
-
 
 class AcmeEntity
 {

--- a/tests/Rules/Asset/AcmeTargetAwareCriteria.php
+++ b/tests/Rules/Asset/AcmeTargetAwareCriteria.php
@@ -1,0 +1,14 @@
+<?php
+
+
+namespace Otobank\PHPStan\Doctrine\Rules\Asset;
+
+use Otobank\Doctrine\Collections\TargetAwareCriteria;
+
+class AcmeTargetAwareCriteria extends TargetAwareCriteria
+{
+    public static function getTargetClass() : string
+    {
+        return AcmeEntity::class;
+    }
+}

--- a/tests/Rules/Asset/AcmeTargetAwareCriteria.php
+++ b/tests/Rules/Asset/AcmeTargetAwareCriteria.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Otobank\PHPStan\Doctrine\Rules\Asset;
 
 use Otobank\Doctrine\Collections\TargetAwareCriteria;

--- a/tests/Rules/Asset/ComparisonCaller.php
+++ b/tests/Rules/Asset/ComparisonCaller.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Otobank\PHPStan\Doctrine\Rules\Asset;
+
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\Expr\Comparison;
+
+class ComparisonCaller
+{
+    public function new() : void
+    {
+        new Comparison('field', 'eq', 1);
+    }
+
+    public function call() : void
+    {
+        Criteria::expr()->eq('field', 'value');
+    }
+}

--- a/tests/Rules/Asset/NonTargetAwareCriteria.php
+++ b/tests/Rules/Asset/NonTargetAwareCriteria.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Otobank\PHPStan\Doctrine\Rules\Asset;
+
+use Doctrine\Common\Collections\Criteria;
+
+class NonTargetAwareCriteria extends Criteria
+{
+}

--- a/tests/Rules/Asset/NonTargetAwareCriteriaCaller.php
+++ b/tests/Rules/Asset/NonTargetAwareCriteriaCaller.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Otobank\PHPStan\Doctrine\Rules\Asset;
+
+class NonTargetAwareCriteriaCaller
+{
+    public function methodCallNonTargetAwareCriteria() : void
+    {
+        $criteria = new NonTargetAwareCriteria();
+        $criteria->where(NonTargetAwareCriteria::expr()->eq('foo', 1));
+    }
+}

--- a/tests/Rules/Asset/TargetAwareComparisonCaller.php
+++ b/tests/Rules/Asset/TargetAwareComparisonCaller.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Otobank\PHPStan\Doctrine\Rules\Asset;
+
+class TargetAwareComparisonCaller
+{
+    public function accessFiledShouldNotRaiseError() : void
+    {
+        $criteria = new AcmeTargetAwareCriteria();
+        $criteria->where(AcmeTargetAwareCriteria::expr()->eq('foo', 1));
+    }
+
+    public function nonAccessFiledShouldNotRaiseError() : void
+    {
+        $criteria = new AcmeTargetAwareCriteria();
+        $criteria->where(AcmeTargetAwareCriteria::expr()->eq('bar', 1));
+    }
+
+    public function methodCallTargetAwareCriteria() : void
+    {
+        $criteria = new AcmeTargetAwareCriteria();
+        $criteria->where(AcmeTargetAwareCriteria::expr()->eq('baz', 1));
+    }
+}

--- a/tests/Rules/Asset/TargetAwareCriteriaCaller.php
+++ b/tests/Rules/Asset/TargetAwareCriteriaCaller.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Otobank\PHPStan\Doctrine\Rules\Asset;
+
+class TargetAwareCriteriaCaller
+{
+    public function accessFiledShouldNotRaiseError() : void
+    {
+        $criteria = new AcmeTargetAwareCriteria();
+        $criteria->orderBy(['foo' => 'asc']);
+    }
+
+    public function nonAccessFiledShouldNotRaiseError() : void
+    {
+        $criteria = new AcmeTargetAwareCriteria();
+        $criteria->orderBy(['bar' => 'asc']);
+    }
+
+    public function methodCallTargetAwareCriteria() : void
+    {
+        $criteria = new AcmeTargetAwareCriteria();
+        $criteria->orderBy(['baz' => 'asc']);
+    }
+}

--- a/tests/Rules/Asset/objectManagerLoader.php
+++ b/tests/Rules/Asset/objectManagerLoader.php
@@ -1,13 +1,12 @@
 <?php
+
 use Doctrine\Common\Persistence\ObjectManager;
 
-return new class implements ObjectManager {
-
+return new class() implements ObjectManager {
     public function getClassMetadata($className)
     {
         if ($className === \Otobank\PHPStan\Doctrine\Rules\Asset\AcmeEntity::class) {
-            return new class implements \Doctrine\Persistence\Mapping\ClassMetadata {
-
+            return new class() implements \Doctrine\Persistence\Mapping\ClassMetadata {
                 public function hasField($fieldName)
                 {
                     return $fieldName === 'foo' || $fieldName === 'bar';

--- a/tests/Rules/Asset/objectManagerLoader.php
+++ b/tests/Rules/Asset/objectManagerLoader.php
@@ -1,0 +1,153 @@
+<?php
+use Doctrine\Common\Persistence\ObjectManager;
+
+return new class implements ObjectManager {
+
+    public function getClassMetadata($className)
+    {
+        if ($className === \Otobank\PHPStan\Doctrine\Rules\Asset\AcmeEntity::class) {
+            return new class implements \Doctrine\Persistence\Mapping\ClassMetadata {
+
+                public function hasField($fieldName)
+                {
+                    return $fieldName === 'foo' || $fieldName === 'bar';
+                }
+
+                public function getAssociationTargetClass($assocName)
+                {
+                    // TODO: Implement getAssociationTargetClass() method.
+                }
+
+                public function getName()
+                {
+                    // TODO: Implement getName() method.
+                }
+
+                public function getIdentifier()
+                {
+                    // TODO: Implement getIdentifier() method.
+                }
+
+                public function getReflectionClass()
+                {
+                    // TODO: Implement getReflectionClass() method.
+                }
+
+                public function isIdentifier($fieldName)
+                {
+                    // TODO: Implement isIdentifier() method.
+                }
+
+                public function hasAssociation($fieldName)
+                {
+                    // TODO: Implement hasAssociation() method.
+                }
+
+                public function isSingleValuedAssociation($fieldName)
+                {
+                    // TODO: Implement isSingleValuedAssociation() method.
+                }
+
+                public function isCollectionValuedAssociation($fieldName)
+                {
+                    // TODO: Implement isCollectionValuedAssociation() method.
+                }
+
+                public function getFieldNames()
+                {
+                    // TODO: Implement getFieldNames() method.
+                }
+
+                public function getIdentifierFieldNames()
+                {
+                    // TODO: Implement getIdentifierFieldNames() method.
+                }
+
+                public function getAssociationNames()
+                {
+                    // TODO: Implement getAssociationNames() method.
+                }
+
+                public function getTypeOfField($fieldName)
+                {
+                    // TODO: Implement getTypeOfField() method.
+                }
+
+                public function isAssociationInverseSide($assocName)
+                {
+                    // TODO: Implement isAssociationInverseSide() method.
+                }
+
+                public function getAssociationMappedByTargetField($assocName)
+                {
+                    // TODO: Implement getAssociationMappedByTargetField() method.
+                }
+
+                public function getIdentifierValues($object)
+                {
+                    // TODO: Implement getIdentifierValues() method.
+                }
+            };
+        }
+    }
+
+    public function find($className, $id)
+    {
+        // TODO: Implement find() method.
+    }
+
+    public function persist($object)
+    {
+        // TODO: Implement persist() method.
+    }
+
+    public function remove($object)
+    {
+        // TODO: Implement remove() method.
+    }
+
+    public function merge($object)
+    {
+        // TODO: Implement merge() method.
+    }
+
+    public function clear($objectName = null)
+    {
+        // TODO: Implement clear() method.
+    }
+
+    public function detach($object)
+    {
+        // TODO: Implement detach() method.
+    }
+
+    public function refresh($object)
+    {
+        // TODO: Implement refresh() method.
+    }
+
+    public function flush()
+    {
+        // TODO: Implement flush() method.
+    }
+
+    public function getRepository($className)
+    {
+        // TODO: Implement getRepository() method.
+    }
+
+    public function getMetadataFactory()
+    {
+        // TODO: Implement getMetadataFactory() method.
+    }
+
+    public function initializeObject($obj)
+    {
+        // TODO: Implement initializeObject() method.
+    }
+
+    public function contains($object)
+    {
+        // TODO: Implement contains() method.
+    }
+};

--- a/tests/Rules/ProhibitComparisonCallRuleTest.php
+++ b/tests/Rules/ProhibitComparisonCallRuleTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Otobank\PHPStan\Doctrine\Rules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+class ProhibitComparisonCallRuleTest extends RuleTestCase
+{
+    public function getRule() : Rule
+    {
+        return new ProhibitComparisonCallRule();
+    }
+
+    public function testProcessNode() : void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Asset/ComparisonCaller.php',
+            ],
+            [
+                [
+                    'Use Otobank\Doctrine\Collections\TargetAwareCriteriaInterface instead of Doctrine\Common\Collections\Criteria',
+                    17,
+                ],
+            ]
+        );
+    }
+}

--- a/tests/Rules/ProhibitComparisonNewRuleTest.php
+++ b/tests/Rules/ProhibitComparisonNewRuleTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Otobank\PHPStan\Doctrine\Rules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+class ProhibitComparisonNewRuleTest extends RuleTestCase
+{
+    public function getRule() : Rule
+    {
+        return new ProhibitComparisonNewRule();
+    }
+
+    public function testProcessNode() : void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Asset/ComparisonCaller.php',
+            ],
+            [
+                [
+                    'Use `Otobank\Doctrine\Collections\TargetAwareCriteriaInterface:expr()` instead of `new Doctrine\Common\Collections\Expr\Comparison`',
+                    12,
+                ],
+            ]
+        );
+    }
+}

--- a/tests/Rules/ProhibitCriteriaCallRuleTest.php
+++ b/tests/Rules/ProhibitCriteriaCallRuleTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Otobank\PHPStan\Doctrine\Rules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+class ProhibitCriteriaCallRuleTest extends RuleTestCase
+{
+    public function getRule() : Rule
+    {
+        return new ProhibitCriteriaCallRule();
+    }
+
+    public function testProcessNode() : void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Asset/NonTargetAwareCriteriaCaller.php',
+            ],
+            [
+                [
+                    'Use Otobank\Doctrine\Collections\TargetAwareCriteriaInterface instead of Doctrine\Common\Collections\Criteria',
+                    10,
+                ],
+            ]
+        );
+    }
+}

--- a/tests/Rules/ProhibitCriteriaNewRuleTest.php
+++ b/tests/Rules/ProhibitCriteriaNewRuleTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Otobank\PHPStan\Doctrine\Rules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+class ProhibitCriteriaNewRuleTest extends RuleTestCase
+{
+    public function getRule() : Rule
+    {
+        return new ProhibitCriteriaNewRule();
+    }
+
+    public function testProcessNode() : void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Asset/NonTargetAwareCriteriaCaller.php',
+            ],
+            [
+                [
+                    'Use Otobank\Doctrine\Collections\TargetAwareCriteriaInterface instead of Doctrine\Common\Collections\Criteria',
+                    9,
+                ],
+            ]
+        );
+    }
+}

--- a/tests/Rules/ValidateFieldComparisonCallRuleTest.php
+++ b/tests/Rules/ValidateFieldComparisonCallRuleTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Otobank\PHPStan\Doctrine\Rules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStan\Type\Doctrine\ObjectMetadataResolver;
+
+class ValidateFieldComparisonCallRuleTest extends RuleTestCase
+{
+    /**
+     * @throws \PHPStan\ShouldNotHappenException
+     */
+    public function getRule() : Rule
+    {
+        $objectMetadataResolver = new ObjectMetadataResolver(
+            __DIR__ . '/Asset/objectManagerLoader.php',
+            null
+        );
+
+        return new ValidateFieldComparisonCallRule($objectMetadataResolver);
+    }
+
+    public function testProcessNode() : void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Asset/TargetAwareComparisonCaller.php',
+            ],
+            [
+                [
+                    'Otobank\PHPStan\Doctrine\Rules\Asset\AcmeEntity::$bar accessor is missing',
+                    16,
+                ],
+                [
+                    'Otobank\PHPStan\Doctrine\Rules\Asset\AcmeEntity::$baz field is missing',
+                    22,
+                ],
+                [
+                    'Otobank\PHPStan\Doctrine\Rules\Asset\AcmeEntity::$baz accessor is missing',
+                    22,
+                ],
+            ]
+        );
+    }
+}

--- a/tests/Rules/ValidateFieldCriteriaCallRuleTest.php
+++ b/tests/Rules/ValidateFieldCriteriaCallRuleTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Otobank\PHPStan\Doctrine\Rules;
+
+
+use Otobank\PHPStan\Doctrine\Type\CriteriaMethodReturnTypeExtension;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStan\Type\Doctrine\ObjectMetadataResolver;
+
+class ValidateFieldCriteriaCallRuleTest extends RuleTestCase
+{
+    /**
+     * @throws \PHPStan\ShouldNotHappenException
+     */
+    public function getRule(): Rule
+    {
+        $objectMetadataResolver = new ObjectMetadataResolver(
+            __DIR__ . '/Asset/objectManagerLoader.php',
+            null
+        );
+
+        return new ValidateFieldCriteriaCallRule($objectMetadataResolver);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getDynamicMethodReturnTypeExtensions(): array
+    {
+        return [
+            new CriteriaMethodReturnTypeExtension()
+        ];
+    }
+
+    public function testProcessNode(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Asset/TargetAwareCriteriaCaller.php',
+            ],
+            [
+                [
+                    'Otobank\PHPStan\Doctrine\Rules\Asset\AcmeEntity::$bar accessor is missing',
+                    16,
+                ],
+                [
+                    'Otobank\PHPStan\Doctrine\Rules\Asset\AcmeEntity::$baz field is missing',
+                    22,
+                ],
+                [
+                    'Otobank\PHPStan\Doctrine\Rules\Asset\AcmeEntity::$baz accessor is missing',
+                    22,
+                ],
+            ]
+        );
+    }
+}

--- a/tests/Rules/ValidateFieldCriteriaCallRuleTest.php
+++ b/tests/Rules/ValidateFieldCriteriaCallRuleTest.php
@@ -2,7 +2,6 @@
 
 namespace Otobank\PHPStan\Doctrine\Rules;
 
-
 use Otobank\PHPStan\Doctrine\Type\CriteriaMethodReturnTypeExtension;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
@@ -13,7 +12,7 @@ class ValidateFieldCriteriaCallRuleTest extends RuleTestCase
     /**
      * @throws \PHPStan\ShouldNotHappenException
      */
-    public function getRule(): Rule
+    public function getRule() : Rule
     {
         $objectMetadataResolver = new ObjectMetadataResolver(
             __DIR__ . '/Asset/objectManagerLoader.php',
@@ -24,16 +23,16 @@ class ValidateFieldCriteriaCallRuleTest extends RuleTestCase
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
-    public function getDynamicMethodReturnTypeExtensions(): array
+    public function getDynamicMethodReturnTypeExtensions() : array
     {
         return [
-            new CriteriaMethodReturnTypeExtension()
+            new CriteriaMethodReturnTypeExtension(),
         ];
     }
 
-    public function testProcessNode(): void
+    public function testProcessNode() : void
     {
         $this->analyse(
             [


### PR DESCRIPTION
## Summary
 - Adding some unit tests in order to check various version to be work.
 - Adding missing composer dependencies to require section, and add `~0.12` version constraint for PHPStan.

### Improvement

|    Q        |   A
|------------ | ------
| New Feature | no
| RFC         | no
| BC Break    | no

