### PR TITLE
Doctrine Collection が IntersectionType や UnionType の場合でもチェックできるようにした

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "phpstan/phpstan": "^0.12.4",
         "phpstan/phpstan-doctrine": "^0.12.12",
         "doctrine/collections": "^1.5",
-        "otobank/doctrine-target-aware-criteria": "^0.1.0",
+        "otobank/doctrine-target-aware-criteria": "^0.2.0",
         "nikic/php-parser": "^4.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "~7.1",
         "phpstan/phpstan": "^0.12.4",
-        "phpstan/phpstan-doctrine": "^0.12.9",
+        "phpstan/phpstan-doctrine": "^0.12.12",
         "doctrine/collections": "^1.5",
         "otobank/doctrine-target-aware-criteria": "^0.1.0",
         "nikic/php-parser": "^4.3"

--- a/src/Rules/ProhibitCriteriaCallRule.php
+++ b/src/Rules/ProhibitCriteriaCallRule.php
@@ -27,17 +27,17 @@ class ProhibitCriteriaCallRule implements \PHPStan\Rules\Rule
             return [];
         }
 
-        $type = $scope->getType($node);
+        $calledOnType = $scope->getType($node->var);
 
-        if (! $type instanceof ObjectType) {
+        if (! $calledOnType instanceof ObjectType) {
             return [];
         }
 
-        if (! (new ObjectType(Criteria::class))->isSuperTypeOf($type)->yes()) {
+        if (! (new ObjectType(Criteria::class))->isSuperTypeOf($calledOnType)->yes()) {
             return [];
         }
 
-        if (! (new ObjectType(TargetAwareCriteriaInterface::class))->isSuperTypeOf($type)->yes()) {
+        if (! (new ObjectType(TargetAwareCriteriaInterface::class))->isSuperTypeOf($calledOnType)->yes()) {
             return [
                 sprintf('Use %s instead of %s', TargetAwareCriteriaInterface::class, Criteria::class),
             ];

--- a/tests/Rules/Asset/AcmeAssociationAwareCriteria.php
+++ b/tests/Rules/Asset/AcmeAssociationAwareCriteria.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Otobank\PHPStan\Doctrine\Rules\Asset;
+
+use Otobank\Doctrine\Collections\AssociationAwareCriteria;
+
+class AcmeAssociationAwareCriteria extends AssociationAwareCriteria
+{
+    public static function getTargetClass() : string
+    {
+        return AcmeEntity::class;
+    }
+
+    public static function getAssociationMap() : array
+    {
+        return [
+        ];
+    }
+}

--- a/tests/Rules/Asset/CollectionEntityWithAssociation.php
+++ b/tests/Rules/Asset/CollectionEntityWithAssociation.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Otobank\PHPStan\Doctrine\Rules\Asset;
+
+use Doctrine\Common\Collections\Collection;
+
+class CollectionEntityWithAssociation
+{
+    /** @var Collection */
+    private $items1;
+
+    /** @var Collection|array<AcmeEntity> */
+    private $items2;
+
+    /** @var Collection&iterable<AcmeEntity> */
+    private $items3;
+
+    public function getItems1() : Collection
+    {
+        $criteria = AcmeAssociationAwareCriteria::create();
+
+        return $this->items1->matching($criteria);
+    }
+
+    public function getItems2() : Collection
+    {
+        $criteria = AcmeAssociationAwareCriteria::create();
+
+        return $this->items2->matching($criteria);
+    }
+
+    public function getItems3() : Collection
+    {
+        $criteria = AcmeAssociationAwareCriteria::create();
+
+        return $this->items3->matching($criteria);
+    }
+}

--- a/tests/Rules/Asset/CollectionEntityWithoutAssociation.php
+++ b/tests/Rules/Asset/CollectionEntityWithoutAssociation.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Otobank\PHPStan\Doctrine\Rules\Asset;
+
+use Doctrine\Common\Collections\Collection;
+
+class CollectionEntityWithoutAssociation
+{
+    /** @var Collection */
+    private $items1;
+
+    /** @var Collection|array<AcmeEntity> */
+    private $items2;
+
+    /** @var Collection&iterable<AcmeEntity> */
+    private $items3;
+
+    public function getItems1() : Collection
+    {
+        $criteria = AcmeTargetAwareCriteria::create();
+
+        return $this->items1->matching($criteria);
+    }
+
+    public function getItems2() : Collection
+    {
+        $criteria = AcmeTargetAwareCriteria::create();
+
+        return $this->items2->matching($criteria);
+    }
+
+    public function getItems3() : Collection
+    {
+        $criteria = AcmeTargetAwareCriteria::create();
+
+        return $this->items3->matching($criteria);
+    }
+}

--- a/tests/Rules/Asset/TargetAwareComparisonCaller.php
+++ b/tests/Rules/Asset/TargetAwareComparisonCaller.php
@@ -8,17 +8,20 @@ class TargetAwareComparisonCaller
     {
         $criteria = new AcmeTargetAwareCriteria();
         $criteria->where(AcmeTargetAwareCriteria::expr()->eq('foo', 1));
+        $criteria->where($criteria->expr()->eq('foo', 1));
     }
 
     public function nonAccessFiledShouldNotRaiseError() : void
     {
         $criteria = new AcmeTargetAwareCriteria();
         $criteria->where(AcmeTargetAwareCriteria::expr()->eq('bar', 1));
+        $criteria->where($criteria->expr()->eq('bar', 1));
     }
 
     public function methodCallTargetAwareCriteria() : void
     {
         $criteria = new AcmeTargetAwareCriteria();
         $criteria->where(AcmeTargetAwareCriteria::expr()->eq('baz', 1));
+        $criteria->where($criteria->expr()->eq('baz', 1));
     }
 }

--- a/tests/Rules/ProhibitCollectionCallWithAssociationsRuleTest.php
+++ b/tests/Rules/ProhibitCollectionCallWithAssociationsRuleTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Otobank\PHPStan\Doctrine\Rules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+class ProhibitCollectionCallWithAssociationsRuleTest extends RuleTestCase
+{
+    public function getRule() : Rule
+    {
+        return new ProhibitCollectionCallWithAssociationsRule();
+    }
+
+    public function testWithoutAssociation() : void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Asset/CollectionEntityWithoutAssociation.php',
+            ],
+            [
+            ]
+        );
+    }
+
+    public function testWithAssociation() : void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Asset/CollectionEntityWithAssociation.php',
+            ],
+            [
+                ['Doctrine\Common\Collections\Collection::matching is not accept Otobank\Doctrine\Collections\AssociationAwareCriteriaInterface', 22],
+                ['Doctrine\Common\Collections\Collection::matching is not accept Otobank\Doctrine\Collections\AssociationAwareCriteriaInterface', 29],
+                ['Doctrine\Common\Collections\Collection::matching is not accept Otobank\Doctrine\Collections\AssociationAwareCriteriaInterface', 36],
+            ]
+        );
+    }
+}

--- a/tests/Rules/ValidateFieldComparisonCallRuleTest.php
+++ b/tests/Rules/ValidateFieldComparisonCallRuleTest.php
@@ -31,15 +31,27 @@ class ValidateFieldComparisonCallRuleTest extends RuleTestCase
             [
                 [
                     'Otobank\PHPStan\Doctrine\Rules\Asset\AcmeEntity::$bar accessor is missing',
-                    16,
+                    17,
+                ],
+                [
+                    'Otobank\PHPStan\Doctrine\Rules\Asset\AcmeEntity::$bar accessor is missing',
+                    18,
                 ],
                 [
                     'Otobank\PHPStan\Doctrine\Rules\Asset\AcmeEntity::$baz field is missing',
-                    22,
+                    24,
                 ],
                 [
                     'Otobank\PHPStan\Doctrine\Rules\Asset\AcmeEntity::$baz accessor is missing',
-                    22,
+                    24,
+                ],
+                [
+                    'Otobank\PHPStan\Doctrine\Rules\Asset\AcmeEntity::$baz field is missing',
+                    25,
+                ],
+                [
+                    'Otobank\PHPStan\Doctrine\Rules\Asset\AcmeEntity::$baz accessor is missing',
+                    25,
                 ],
             ]
         );

--- a/tests/Rules/ValidateFieldComparisonCallRuleTest.php
+++ b/tests/Rules/ValidateFieldComparisonCallRuleTest.php
@@ -14,6 +14,7 @@ class ValidateFieldComparisonCallRuleTest extends RuleTestCase
     public function getRule() : Rule
     {
         $objectMetadataResolver = new ObjectMetadataResolver(
+            $this->createReflectionProvider(),
             __DIR__ . '/Asset/objectManagerLoader.php',
             null
         );

--- a/tests/Rules/ValidateFieldCriteriaCallRuleTest.php
+++ b/tests/Rules/ValidateFieldCriteriaCallRuleTest.php
@@ -15,6 +15,7 @@ class ValidateFieldCriteriaCallRuleTest extends RuleTestCase
     public function getRule() : Rule
     {
         $objectMetadataResolver = new ObjectMetadataResolver(
+            $this->createReflectionProvider(),
             __DIR__ . '/Asset/objectManagerLoader.php',
             null
         );


### PR DESCRIPTION
* ProhibitCollectionCallWithAssociationsRule を IntersectionType と UnionType にも対応
  * Collection&iterable<Foo> の形式に対応するため
* phpstan/phpstan-doctrine を 0.12.12 以上にした
  * 0.12.12 から ObjectMetadataResolver のコンストラクタの引数が変わったため
* otobank/doctrine-target-aware-criteria を 0.2.0 以上にした
  * TargetAwareCriteria::create() の戻り値のタイプヒントを修正するため
* テストの拡充
