### PR TITLE
Enable PHP8 compat

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
-          php-version: "7.2"
+          php-version: "8.1"
 
       - name: "Validate Composer"
         run: "composer validate"
@@ -41,9 +41,8 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "7.2"
-          - "7.3"
-          - "7.4"
+          - "8.1"
+          - "8.2"
         dependencies:
           - "lowest"
           - "highest"
@@ -77,12 +76,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "7.2"
-          - "7.3"
-          - "7.4"
-        dependencies:
-          - "lowest"
-          - "highest"
+          - "8.2"
 
     steps:
       - name: "Checkout"
@@ -95,12 +89,7 @@ jobs:
           php-version: "${{ matrix.php-version }}"
           tools: composer:v2
 
-      - name: "Install lowest dependencies"
-        if: ${{ matrix.dependencies == 'lowest' }}
-        run: "composer update --prefer-lowest --no-interaction --no-progress"
-
-      - name: "Install highest dependencies"
-        if: ${{ matrix.dependencies == 'highest' }}
+      - name: "Install dependencies"
         run: "composer update --no-interaction --no-progress"
 
       - name: "PHPStan"

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,11 +1,13 @@
 <?php
 
-$finder = \PhpCsFixer\Finder::create()
-    ->exclude('vendor')
-    ->in(__DIR__)
-;
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
 
-return \PhpCsFixer\Config::create()
+$finder = (new Finder())
+    ->exclude('vendor')
+    ->in(__DIR__);
+
+return (new Config())
     ->setRules([
         '@Symfony' => true,
         'concat_space' => false,
@@ -16,5 +18,4 @@ return \PhpCsFixer\Config::create()
         'increment_style' => ['style' => 'post'],
     ])
     ->setFinder($finder)
-    ->setUsingCache(false)
-;
+    ->setUsingCache(false);

--- a/composer.json
+++ b/composer.json
@@ -10,17 +10,17 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^8.1",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-doctrine": "^1.3",
         "doctrine/collections": "^1.8",
-        "otobank/doctrine-target-aware-criteria": "^0.3",
+        "otobank/doctrine-target-aware-criteria": "dev-php8 as 0.3",
         "nikic/php-parser": "^4.13",
         "doctrine/persistence": "^2.5"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.14",
-        "phpunit/phpunit": "^8",
+        "friendsofphp/php-cs-fixer": "^v3.0",
+        "phpunit/phpunit": "^9.6",
         "doctrine/common": "^3.4",
         "phpstan/phpstan-phpunit": "^1.1",
         "doctrine/dbal": "^2.7.1",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,19 +1,16 @@
-<phpunit
- xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
- xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- bootstrap="tests/bootstrap.php"
->
-    <testsuites>
-        <testsuite name="main">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <php>
-        <ini name="error_reporting" value="-1" />
-    </php>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="tests/bootstrap.php">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="main">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <ini name="error_reporting" value="-1"/>
+  </php>
 </phpunit>

--- a/tests/Rules/Asset/AcmeEntity.php
+++ b/tests/Rules/Asset/AcmeEntity.php
@@ -13,7 +13,9 @@ class AcmeEntity
      * @var int|null
      *
      * @ORM\Id
+     *
      * @ORM\GeneratedValue
+     *
      * @ORM\Column(type="integer", options={"unsigned": true})
      */
     private $id;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,11 +6,4 @@ use PHPStan\Testing\PHPStanTestCase;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-if (method_exists(Doctrine\Common\Annotations\AnnotationRegistry::class, 'registerLoader')) {
-    // for old doctrine annotations
-    // to avoid "Doctrine\Common\Annotations\AnnotationException: [Semantical Error] The annotation "@Doctrine\ORM\Mapping\Embeddable"
-    //            in class Otobank\PHPStan\Doctrine\Rules\Asset\EmbeddedEntity does not exist, or could not be auto-loaded."
-    \Doctrine\Common\Annotations\AnnotationRegistry::registerLoader('class_exists');
-}
-
 PHPStanTestCase::getContainer();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * PHP 最小要件を8.1に更新しました（従来は7.2以上）
  * PHPUnit 9.6、PHP-CS-Fixer 3.0など開発ツールを最新版に更新
  * テスト環境設定ファイルを現在の標準に対応

<!-- end of auto-generated comment: release notes by coderabbit.ai -->